### PR TITLE
fix readme: add code block language

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,8 @@ npm i gatsby-plugin-appsync
 
 Rename **.env.example** created by this plugin inside your root folder to your environment name. e.g **.env.development** if NODE_ENV is set to development. Also change the settings there
 
-```GATSBY_GRAPHQL_ENDPOINT=http://localhost:20002/graphql
+```text
+GATSBY_GRAPHQL_ENDPOINT=http://localhost:20002/graphql
 GATSBY_REGION=eu-west-2
 GATSBY_COGNITO_USER_POOL_ID=
 GATSBY_COGNITO_IDENTITY_POOL_ID=


### PR DESCRIPTION
fix error:

```shell
warn unable to find prism language 'gatsby_graphql_endpoint=http://localhost:20002/graphql' for highlighting. applying generic code block
```

see:
- https://github.com/gatsbyjs/gatsby/issues/20926